### PR TITLE
feat: add arguments to the strapi serve command

### DIFF
--- a/packages/strapi/src/executors/serve/schema.json
+++ b/packages/strapi/src/executors/serve/schema.json
@@ -3,7 +3,7 @@
   "type": "object",
   "cli": "nx",
   "title": "Serve executor",
-  "description": "",
+  "description": "Runs the command 'strapi develop'",
   "properties": {
     "production": {
       "type": "boolean",

--- a/packages/strapi/src/executors/serve/serve.impl.ts
+++ b/packages/strapi/src/executors/serve/serve.impl.ts
@@ -1,13 +1,35 @@
 import { ExecutorContext } from '@nrwl/devkit'
-import { execCommand } from '@nx-extend/core'
+import { buildCommand, execCommand } from '@nx-extend/core'
+
+export interface ServeExecutorOptions {
+  /** Starts your application with the autoReload enabled and skip the administration panel build process */
+  build?: boolean;
+  /** Starts your application with the autoReload enabled and the front-end development server. It allows you to customize the administration panel. */
+  watchAdmin?: boolean;
+  /** Starts your application with the autoReload enabled and the front-end development server. */
+  browser?: string;
+}
 
 export async function serveExecutor(
-  options,
+  options: ServeExecutorOptions,
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const { root } = context.workspace.projects[context.projectName]
 
-  return Promise.resolve(execCommand('npx strapi develop', {
+  const {
+    build = true,
+    watchAdmin = false,
+    browser = null,
+  } = options
+
+  const developCommand = buildCommand([
+    'npx strapi develop',
+    !build && '--no-build',
+    watchAdmin && '--watch-admin',
+    browser && `--browser=${browser}`,
+  ])
+
+  return Promise.resolve(execCommand(developCommand, {
     cwd: root
   }))
 }


### PR DESCRIPTION
The `strapi` package has an executor `serve`
The executor is passing through whitelisted arguments from the nx-command.

- --no-build
- --watch-admin
- --browser

Currently possible arguments documented here:  
https://docs.strapi.io/developer-docs/latest/developer-resources/cli/CLI.html#strapi-develop

