### PR TITLE
chore(gcp-functions): project init fixes and cleanup

### DIFF
--- a/packages/gcp-functions/src/generators/init/files-http/package.json.template
+++ b/packages/gcp-functions/src/generators/init/files-http/package.json.template
@@ -1,5 +1,4 @@
 {
   "name": "<%= projectName %>",
-  "version": "0.0.1",
-  "main": "./main.js"
+  "version": "0.0.1"
 }

--- a/packages/gcp-functions/src/generators/init/files-http/src/main.ts.template
+++ b/packages/gcp-functions/src/generators/init/files-http/src/main.ts.template
@@ -1,4 +1,4 @@
-import type { HttpFunction } from '@google-cloud/functions-framework/build/src/functions'
+import type { HttpFunction } from '@google-cloud/functions-framework'
 
 const { foo = 'testBar'} = process.env
 

--- a/packages/gcp-functions/src/generators/init/init.impl.ts
+++ b/packages/gcp-functions/src/generators/init/init.impl.ts
@@ -1,4 +1,5 @@
 import {
+  addDependenciesToPackageJson,
   addProjectConfiguration,
   formatFiles,
   generateFiles,
@@ -54,6 +55,17 @@ function addFiles(host: Tree, options: NormalizedSchema) {
   )
 }
 
+function addProjectDependencies(host: Tree, options: NormalizedSchema) {
+  addDependenciesToPackageJson(
+    host,
+    {},
+    {
+      '@google-cloud/functions-framework': 'latest',
+    },
+    path.join('.', 'package.json')
+  );
+}
+
 export default async function (
   host: Tree,
   options: GcpDeploymentManagerGeneratorSchema
@@ -105,6 +117,7 @@ export default async function (
   })
 
   addFiles(host, normalizedOptions)
+  addProjectDependencies(host, normalizedOptions)
 
   await formatFiles(host)
 }


### PR DESCRIPTION
👋🏻  Hello ^_^

I have been a big fan of Nx for a while and recently had the need to create some Cloud Functions in GCP. After looking at the community plugins, I decided to go with yours as there are other GCP related plugins in your repo should I need them. I had a few issues creating a new project though so, instead of just fixing them for myself, I decided to share the wealth ^_^

Changes:
- `init.impl.ts`: This was my main issue when creating the project. When a project is created, it doesn't add the `@google-cloud/functions-framework` package to the workspace but it's referenced in `main.ts`. Adding this change fixes that issue.
- `main.ts.template`: This was related to the above.  `HttpFunction` is exported at the package's top level so diving deeper isn't needed and, depending on the tsconfig settings used, can sometime cause lint errors. This solves that issue
- `package.json.template`: This change doesn't solve a problem but is cleanup that hopefully helps resolve potential confusion to anyone not familiar with this plugin. The `main.js` file isn't created until build time but the build process generates a new `package.json` in the output path and adds the `main` property with the value of `outputFile`, which is `main.js` by default. So, I think it's a bit clearer to leave it off the project's `package.json` and just leave it to the build executor to add the main property to the one generated for the dist directory.

Let me know if you'd like me to add anything or make any changes. I don't see any unit tests for this plugin so I don't think I have to worry about adding/fixing any of those but I could have just missed them.

Thanks,

-Killian