### PR TITLE
fix(terraform): Fixed apply autoApproval

### DIFF
--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -39,9 +39,9 @@ export function createExecutor(command: string) {
         ...backendConfig.map(
           (config) => `-backend-config="${config.key}=${config.name}"`
         ),
-        command === 'apply' && planFile,
         command === 'plan' && planFile && `-out ${planFile}`,
-        autoApproval && '-auto-approve'
+        command === 'apply' && autoApproval && '-auto-approve',
+        command === 'apply' && planFile
       ]),
       {
         cwd: sourceRoot,


### PR DESCRIPTION
Command signature is `terraform apply [options] [plan file]`.  
Currently `@nx-extend/terraform:apply` executes as `terraform apply defaultplan -auto-approve` which gives  
`Error: Too many command line arguments. Expected at most one positional argument.`