### PR TITLE
Respect Pulumi stack exports

### DIFF
--- a/packages/pulumi/src/generators/init/files/index.ts.template
+++ b/packages/pulumi/src/generators/init/files/index.ts.template
@@ -12,3 +12,4 @@ register({
 })
 
 import './pulumi'
+export * from './pulumi'


### PR DESCRIPTION
This fixes the template so that files are exported correctly from `pulumi.ts`, if any.