### PR TITLE
fix: eslint breaking import order

### DIFF
--- a/packages/pulumi/src/generators/init/files/index.ts.template
+++ b/packages/pulumi/src/generators/init/files/index.ts.template
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 import { loadConfig, register } from 'tsconfig-paths'
 
 const config = loadConfig('.')


### PR DESCRIPTION
fixes #157

ESLint will make the import of `pulumi` go to the top, which makes it run before the tsconfig-paths import.