### PR TITLE
feat: add helper for strong-typed stack references

### DIFF
--- a/packages/pulumi/src/generators/init/files/index.ts.template
+++ b/packages/pulumi/src/generators/init/files/index.ts.template
@@ -15,3 +15,19 @@ register({
 
 import './pulumi'
 export * from './pulumi'
+
+import * as pulumi from '@pulumi/pulumi';
+
+type ExportTypes = typeof import('./pulumi');
+type ExportTypesKey = keyof ExportTypes;
+type ExportTypesValue<TKey extends ExportTypesKey> = ExportTypes[TKey];
+
+type StrongTypedStackReference = Omit<pulumi.StackReference, 'getOutput' | 'requireOutput'> & {
+  getOutput<T extends ExportTypesKey>(name: pulumi.Input<T>): ExportTypesValue<T>;
+  requireOutput<T extends ExportTypesKey>(name: pulumi.Input<T>): ExportTypesValue<T>;
+};
+
+export function getStackReference() {
+  const stack = pulumi.getStack();
+  return new pulumi.StackReference(`organization/<%= name %>/${stack}`) as StrongTypedStackReference;
+}


### PR DESCRIPTION
Today, when working with [Pulumi Stack References](https://www.pulumi.com/learn/building-with-pulumi/stack-references/), they are not strong-typed.

With this project, we have the potential to make them strong-typed by emitting just a small helper method that does just that.

I think the end-result is really cool.

So now, when referencing other stacks, their outputs and return types etc are strong-typed.