### PR TITLE
fix: update executors

### DIFF
--- a/packages/pulumi/executors.json
+++ b/packages/pulumi/executors.json
@@ -9,6 +9,11 @@
       "implementation": "./src/executors/preview/preview.impl",
       "schema": "./src/executors/preview/schema.json",
       "description": "preview executor"
+    },
+    "refresh": {
+      "implementation": "./src/executors/refresh/refresh.impl",
+      "schema": "./src/executors/refresh/schema.json",
+      "description": "refresh executor"
     }
   },
   "builders": {


### PR DESCRIPTION
May fix #166.

Unsure why the executors are both in the "builders" and "executors" section though? Aren't they just executors? I guess builders is something else, right?

If that's the case, we should remove the builders section.