### PR TITLE
Added missing fmt target in project configuration.

### DIFF
--- a/packages/terraform/src/generators/init/init.impl.ts
+++ b/packages/terraform/src/generators/init/init.impl.ts
@@ -58,6 +58,12 @@ export default async function (
           ciMode: true
         }
       },
+      fmt: {
+        executor: '@nx-extend/terraform:fmt',
+        options: {
+          ciMode: true
+        }
+      },
       apply: {
         executor: '@nx-extend/terraform:apply',
         options: {


### PR DESCRIPTION
I was not able to run `nx run <terraform-project-name>:fmt --recursive` due to a missing target, therefore I just added it.

@TriPSs Could you take a look?