### PR TITLE
feat(e2e-runner): enable or disable target logging via options

### DIFF
--- a/packages/e2e-runner/README.md
+++ b/packages/e2e-runner/README.md
@@ -34,6 +34,7 @@ Each target can be configured with the following options.
   env?: { [key: string]: string } // Extra parameters provided to the target on startup.
   reuseExistingServer?: boolean // Set to true to allow using a previously started target.
   rejectUnauthorized?: boolean // Set to false to allow the use of self-signed certificates in your target.
+  logging?: boolean // Set to true to forwards the logs of the target, set to false to hide the logs of the target. When undefined, the logs are only forwarded with the `--verbose` flag.
 }
 ```
 
@@ -56,7 +57,8 @@ Example target
         {
           "target": "api:serve",
           "checkUrl": "http://localhost:9000/health",
-          "checkMaxTries": 50
+          "checkMaxTries": 50,
+          "logging": false
         }
       ]
     }


### PR DESCRIPTION
Use the new `logging` option on a target to either enable, or disable the logging output for the specified target.

Closes #202

I tried adding some component tests; but I can't seem to mock `child_process.spawn` properly without adding extra libraries.
