### PR TITLE
feat: don't emit dots in CLI output

### DIFF
--- a/packages/pulumi/src/executors/preview/preview.impl.ts
+++ b/packages/pulumi/src/executors/preview/preview.impl.ts
@@ -22,7 +22,7 @@ export default async function creatExecutor(
   execSync(
     buildCommand([
       'PULUMI_EXPERIMENTAL=true',
-      'pulumi preview --diff',
+      'pulumi preview --diff --suppress-progress',
       options.stack && `--stack=${options.stack}`
     ]),
     {

--- a/packages/pulumi/src/executors/refresh/refresh.impl.ts
+++ b/packages/pulumi/src/executors/refresh/refresh.impl.ts
@@ -24,7 +24,7 @@ export default async function createExecutor(
   execSync(
     buildCommand([
       'PULUMI_EXPERIMENTAL=true',
-      'pulumi refresh',
+      'pulumi refresh --suppress-progress',
       options.stack && `--stack=${options.stack}`,
       options.skipPreview && '--skip-preview',
       options.yes && '--yes'

--- a/packages/pulumi/src/executors/up/up.impl.ts
+++ b/packages/pulumi/src/executors/up/up.impl.ts
@@ -25,7 +25,7 @@ export default async function createExecutor(
 
   execSync(
     buildCommand([
-      'pulumi up',
+      'pulumi up --suppress-progress',
       options.stack && `--stack=${options.stack}`,
       options.skipPreview && '--skip-preview',
       options.yes && '--yes',


### PR DESCRIPTION
This is a new feature I helped introduce in Pulumi: https://github.com/pulumi/pulumi/releases/tag/v3.105.0

It doesn't emit a gazillion dots to the standard out.