### PR TITLE
fix(terraform): fix terraform validate executor schema and command

### DIFF
--- a/packages/terraform/src/executors/validate/schema.json
+++ b/packages/terraform/src/executors/validate/schema.json
@@ -6,5 +6,4 @@
   "title": "Validate executor",
   "description": "Validate",
   "properties": {}
-  }
 }

--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -54,7 +54,7 @@ export function createExecutor(command: string) {
         command === 'init' && upgrade && '-upgrade',
         command === 'init' && migrateState && '-migrate-state',
         command === 'providers' && lock && 'lock',
-        command === 'validate',
+        command === 'validate' && '',
         command === 'test' && varFile && `--var-file ${varFile}`,
       ]),
       {

--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -54,7 +54,6 @@ export function createExecutor(command: string) {
         command === 'init' && upgrade && '-upgrade',
         command === 'init' && migrateState && '-migrate-state',
         command === 'providers' && lock && 'lock',
-        command === 'validate' && '',
         command === 'test' && varFile && `--var-file ${varFile}`,
       ]),
       {


### PR DESCRIPTION
Fix schema typo.

Validate command needs `''` added otherwise the command ends up being `terraform validate true`