### PR TITLE
feat(gcp-functions): allow keeping optional peerDeps and devDeps

### DIFF
--- a/packages/gcp-functions/src/executors/build/build.impl.ts
+++ b/packages/gcp-functions/src/executors/build/build.impl.ts
@@ -8,6 +8,7 @@ import { generatePackageJson } from '../../utils/generate-package-json'
 
 export interface RawOptions extends WebpackExecutorOptions {
   generateLockFile?: boolean
+  omitOptionalDependencies?: boolean
 }
 
 export async function buildExecutor(
@@ -34,6 +35,7 @@ export async function buildExecutor(
       context,
       options,
       value.outfile,
+      rawOptions.omitOptionalDependencies,
       rawOptions.generateLockFile
     )
   }

--- a/packages/gcp-functions/src/executors/build/schema.json
+++ b/packages/gcp-functions/src/executors/build/schema.json
@@ -90,6 +90,11 @@
       "default": false,
       "x-deprecated": "The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling."
     },
+    "omitOptionalDependencies": {
+      "type": "boolean",
+      "description": "If omitOptionalDependencies flag is set, it will remove devDependencies and optional peerDependencies",
+      "default": true
+    },
     "maxWorkers": {
       "type": "number",
       "description": "Number of workers to use for type checking. (defaults to # of CPUS - 2)"

--- a/packages/gcp-functions/src/utils/generate-package-json.ts
+++ b/packages/gcp-functions/src/utils/generate-package-json.ts
@@ -18,7 +18,8 @@ export const generatePackageJson = (
   context: ExecutorContext,
   options: WebpackExecutorOptions,
   outFile: string,
-  generateLockFile?: boolean
+  omitOptionalDependencies = true,
+  generateLockFile?: boolean,
 ) => {
   const { root } = context.workspace.projects[context.projectName]
 
@@ -27,7 +28,7 @@ export const generatePackageJson = (
     readCachedProjectGraph(),
     {
       root: context.root,
-      isProduction: true
+      isProduction: omitOptionalDependencies
     }
   )
 
@@ -35,7 +36,9 @@ export const generatePackageJson = (
     packageJson.main = options.outputFileName || 'main.js'
   }
 
-  delete packageJson.devDependencies
+  if (omitOptionalDependencies) {
+    delete packageJson.devDependencies
+  }
 
   const dependencies = {}
   const buildFile = fs.readFileSync(outFile, 'utf8')


### PR DESCRIPTION
Fixes #250 

Adds an option called `omitOptionalDependencies`. This will control the `isProduction` flag in `@nx/js`'s `createPackageJson` function.