### PR TITLE
fix: add license

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nx-extend/core",
   "version": "6.0.1",
+  "license": "MIT",
   "main": "src/index.js",
   "nx-migrations": {
     "migrations": "./migrations.json"


### PR DESCRIPTION
In the company I work for, we must respect all Open Source licenses. And since this is unlicensed, we can't use it anymore unless we provide the license here.