### PR TITLE
fix: add missing stack property

### DIFF
--- a/packages/pulumi/src/executors/preview/schema.json
+++ b/packages/pulumi/src/executors/preview/schema.json
@@ -6,6 +6,10 @@
   "title": "Preview executor",
   "description": "Preview",
   "properties": {
+    "stack": {
+      "type": "string",
+      "description": "The target stack to use, if specified."
+    },
     "root": {
       "type": "string",
       "description": "The working directory to run Pulumi commands from, if specified."

--- a/packages/pulumi/src/executors/refresh/schema.json
+++ b/packages/pulumi/src/executors/refresh/schema.json
@@ -6,6 +6,10 @@
   "title": "Refresh executor",
   "description": "Refresh",
   "properties": {
+    "stack": {
+      "type": "string",
+      "description": "The target stack to use, if specified."
+    },
     "root": {
       "type": "string",
       "description": "The working directory to run Pulumi commands from, if specified."

--- a/packages/pulumi/src/executors/up/schema.json
+++ b/packages/pulumi/src/executors/up/schema.json
@@ -6,6 +6,10 @@
   "title": "Apply executor",
   "description": "Apply",
   "properties": {
+    "stack": {
+      "type": "string",
+      "description": "The target stack to use, if specified."
+    },
     "root": {
       "type": "string",
       "description": "The working directory to run Pulumi commands from, if specified."


### PR DESCRIPTION
Due to recent changes in NX, non-existent options are no longer passed down to the executor.

I found that the "stack" option at least isn't anymore. I suspect it's because it doesn't exist in the schema.