### PR TITLE
Add fix to support passing in JSON as string via command line arguments

### DIFF
--- a/packages/gcp-cloud-run/package.json
+++ b/packages/gcp-cloud-run/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx-extend/gcp-cloud-run",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "homepage": "https://github.com/TriPSs/nx-extend/blob/master/packages/gcp-cloud-run/README.md",
   "bugs": {
     "url": "https://github.com/tripss/nx-extend/issues"

--- a/packages/gcp-cloud-run/src/utils/get-valid-secrets.ts
+++ b/packages/gcp-cloud-run/src/utils/get-valid-secrets.ts
@@ -8,7 +8,11 @@ export function getValidSecrets(
   }
 
   if (typeof secrets === 'string') {
-    secrets = JSON.parse(secrets)
+    try {
+      secrets = JSON.parse(secrets)
+    } catch {
+      throw new Error('Invalid JSON passed to secrets argument')
+    }
   }
 
   if (!Array.isArray(secrets)) {

--- a/packages/gcp-cloud-run/src/utils/get-valid-secrets.ts
+++ b/packages/gcp-cloud-run/src/utils/get-valid-secrets.ts
@@ -1,21 +1,33 @@
 import { logger } from '@nx/devkit'
 
-export function getValidSecrets(secrets?: string[] | Record<string, string>): string[] {
+export function getValidSecrets(
+  secrets?: string | string[] | Record<string, string>
+): string[] {
   if (!secrets) {
     return []
   }
 
-  if (!Array.isArray(secrets)) {
-    secrets = Object.keys(secrets).map((secret) => `${secret}=${secrets[secret]}`)
+  if (typeof secrets === 'string') {
+    secrets = JSON.parse(secrets)
   }
 
-  return secrets.map((secret) => {
-    if (secret.includes('=') && secret.includes(':')) {
-      return secret
-    }
+  if (!Array.isArray(secrets)) {
+    secrets = Object.keys(secrets).map(
+      (secret) => `${secret}=${secrets[secret]}`
+    )
+  }
 
-    logger.warn(`"${secret}" is not a valid secret! It should be in the following format "ENV_VAR_NAME=SECRET:VERSION"`)
+  return secrets
+    .map((secret) => {
+      if (secret.includes('=') && secret.includes(':')) {
+        return secret
+      }
 
-    return false
-  }).filter(Boolean) as string[]
+      logger.warn(
+        `"${secret}" is not a valid secret! It should be in the following format "ENV_VAR_NAME=SECRET:VERSION"`
+      )
+
+      return false
+    })
+    .filter(Boolean) as string[]
 }

--- a/packages/gcp-functions/package.json
+++ b/packages/gcp-functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx-extend/gcp-functions",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "homepage": "https://github.com/TriPSs/nx-extend/blob/master/packages/gcp-functions/README.md",
   "bugs": {
     "url": "https://github.com/tripss/nx-extend/issues"

--- a/packages/gcp-functions/src/utils/get-valid-secrets.ts
+++ b/packages/gcp-functions/src/utils/get-valid-secrets.ts
@@ -1,21 +1,33 @@
 import { logger } from '@nx/devkit'
 
-export function getValidSecrets(secrets?: string[] | Record<string, string>): string[] {
+export function getValidSecrets(
+  secrets?: string | string[] | Record<string, string>
+): string[] {
   if (!secrets) {
     return []
   }
 
-  if (!Array.isArray(secrets)) {
-    secrets = Object.keys(secrets).map((secret) => `${secret}=${secrets[secret]}`)
+  if (typeof secrets === 'string') {
+    secrets = JSON.parse(secrets)
   }
 
-  return secrets.map((secret) => {
-    if (secret.includes('=') && secret.includes(':')) {
-      return secret
-    }
+  if (!Array.isArray(secrets)) {
+    secrets = Object.keys(secrets).map(
+      (secret) => `${secret}=${secrets[secret]}`
+    )
+  }
 
-    logger.warn(`"${secret}" is not a valid secret! It should be in the following format "ENV_VAR_NAME=SECRET:VERSION"`)
+  return secrets
+    .map((secret) => {
+      if (secret.includes('=') && secret.includes(':')) {
+        return secret
+      }
 
-    return false
-  }).filter(Boolean) as string[]
+      logger.warn(
+        `"${secret}" is not a valid secret! It should be in the following format "ENV_VAR_NAME=SECRET:VERSION"`
+      )
+
+      return false
+    })
+    .filter(Boolean) as string[]
 }

--- a/packages/gcp-functions/src/utils/get-valid-secrets.ts
+++ b/packages/gcp-functions/src/utils/get-valid-secrets.ts
@@ -1,33 +1,29 @@
 import { logger } from '@nx/devkit'
 
-export function getValidSecrets(
-  secrets?: string | string[] | Record<string, string>
-): string[] {
+export function getValidSecrets(secrets?: string | string[] | Record<string, string>): string[] {
   if (!secrets) {
     return []
   }
 
   if (typeof secrets === 'string') {
-    secrets = JSON.parse(secrets)
+    try {
+      secrets = JSON.parse(secrets)
+    } catch {
+      throw new Error('Invalid JSON passed to secrets argument')
+    }
   }
 
-  if (!Array.isArray(secrets)) {
-    secrets = Object.keys(secrets).map(
-      (secret) => `${secret}=${secrets[secret]}`
-    )
+   if (!Array.isArray(secrets)) {
+    secrets = Object.keys(secrets).map((secret) => `${secret}=${secrets[secret]}`)
   }
 
-  return secrets
-    .map((secret) => {
-      if (secret.includes('=') && secret.includes(':')) {
-        return secret
-      }
+  return secrets.map((secret) => {
+    if (secret.includes('=') && secret.includes(':')) {
+      return secret
+    }
 
-      logger.warn(
-        `"${secret}" is not a valid secret! It should be in the following format "ENV_VAR_NAME=SECRET:VERSION"`
-      )
+    logger.warn(`"${secret}" is not a valid secret! It should be in the following format "ENV_VAR_NAME=SECRET:VERSION"`)
 
-      return false
-    })
-    .filter(Boolean) as string[]
+    return false
+  }).filter(Boolean) as string[]
 }


### PR DESCRIPTION
When running a command like the one below, the secrets are parsed as if they're an array/object. This should resolve that

```bash
nx deploy "some-function" ... "--secrets" "[ENV_FILE=some-env]"
```