### PR TITLE
feat(vercel): add archive option for deploy executor

### DIFF
--- a/packages/vercel/src/executors/deploy/deploy.impl.ts
+++ b/packages/vercel/src/executors/deploy/deploy.impl.ts
@@ -11,6 +11,7 @@ import { vercelToken } from '../../utils/vercel-token'
 export interface DeployOptions {
   buildTarget?: string
   regions?: string
+  archive?: 'tgz'
 }
 
 export async function deployExecutor(
@@ -51,6 +52,7 @@ export async function deployExecutor(
     context.configurationName === 'production' && '--prod',
     vercelToken && `--token=${vercelToken}`,
     options.regions && `--regions=${options.regions}`,
+    options.archive && `--archive=${options.archive}`,
 
     USE_VERBOSE_LOGGING && '--debug'
   ]), {

--- a/packages/vercel/src/executors/deploy/schema.json
+++ b/packages/vercel/src/executors/deploy/schema.json
@@ -9,6 +9,18 @@
     "regions": {
       "type": "string",
       "description": "Regions to deploy to"
+    },
+    "buildTarget": {
+      "type": "string",
+      "description": "Build target to deploy"
+    },
+    "archive": {
+      "type": "string",
+      "description": "Type of archive to use when uploading the build",
+      "enum": ["tgz"],
+      "$default": "atom",
+      "x-prompt": "Archive type",
+      "x-display": "radio"
     }
   }
 }


### PR DESCRIPTION
This option can be passed to the executor options to make the Vercel CLI archive the build before uploading.

This is required for projects with >15000 files, as the Vercel CLI will otherwise throw an error: 
```
Error: Invalid request: `files` should NOT have more than 15000 items, received 17185.
```

Thanks for creating this and please let me know if you'd like me to add anything else to the PR 😄 