### PR TITLE
fix(vercel): remove  archive option for deploy executor

### DIFF
--- a/packages/vercel/src/executors/deploy/schema.json
+++ b/packages/vercel/src/executors/deploy/schema.json
@@ -18,7 +18,6 @@
       "type": "string",
       "description": "Type of archive to use when uploading the build",
       "enum": ["tgz"],
-      "$default": "atom",
       "x-prompt": "Archive type",
       "x-display": "radio"
     }


### PR DESCRIPTION
Just cleaning the default value that was left there by mistake 😄 