### PR TITLE
bug(terraform): Fix path resolution for nested modules

### DIFF
--- a/packages/terraform/src/graph.ts
+++ b/packages/terraform/src/graph.ts
@@ -47,7 +47,10 @@ export const createDependencies: CreateDependencies = async (_, ctx) => {
           continue
         }
 
-        const depSourceAbs = path.resolve(file.file, depSourcePathRel)
+        const depSourceAbs = path.resolve(
+          path.dirname(file.file),
+          depSourcePathRel
+        )
 
         const depSourceRelativeToWorkspace = path.relative(
           workspaceRoot,


### PR DESCRIPTION
The path resolution for deeply nested modules has a bug where it doesn't resolve the correct absolute path.