### PR TITLE
Pin version of shadcn, fixes #309

### DIFF
--- a/packages/shadcn-ui/src/executors/add/add.impl.ts
+++ b/packages/shadcn-ui/src/executors/add/add.impl.ts
@@ -14,7 +14,7 @@ export async function addExecutor(
 
   return execPackageManagerCommand(
     buildCommand([
-      'shadcn-ui@latest add',
+      'shadcn-ui@0.8.0 add',
       (options.component ?? '').length === 0 ? '--all' : options.component,
       options.overwrite && '--overwrite',
       '--path=src',


### PR DESCRIPTION
The latest version of the UI package does not include the CLI anymore, it's published under `shadcn` now - this PR fixes that by pinning the version to `0.8.0`, the latest previous version that works.

It would be nice to start using the new CLI, but it's incompatible with the current setup inside NX: it expects package.json and components.json to be defined within the same directory. I think the better approach would be to implement a NX-specific version of the `add` command instead of using the upstream CLI - it's [not particularly complex](https://github.com/shadcn-ui/ui/blob/main/packages/cli/src/commands/add.ts).