### PR TITLE
chore(strapi): update to v5

### DIFF
--- a/packages/strapi/package.json
+++ b/packages/strapi/package.json
@@ -16,8 +16,8 @@
   "license": "MIT",
   "main": "src/index.js",
   "dependencies": {
-    "@strapi/generate-new": "4.25.11",
-    "@strapi/strapi": "4.25.11"
+    "@strapi/generate-new": "4.25.12",
+    "@strapi/strapi": "5.3.0"
   },
   "peerDependencies": {
     "@nx/devkit": "^20.0.0"

--- a/packages/strapi/src/generators/init/init.impl.ts
+++ b/packages/strapi/src/generators/init/init.impl.ts
@@ -43,7 +43,6 @@ function generateStrapi(options: NormalizedSchema) {
     strapiDependencies: [
       '@strapi/strapi',
       '@strapi/plugin-users-permissions',
-      '@strapi/plugin-i18n'
     ],
     additionalsDependencies: {},
     useTypescript: true


### PR DESCRIPTION
Changed both the main `strapi` and `generate-new` packages to the latest version. Removed the i18n plugin from the dependencies used at initialized, because this is now included in the core of Strapi.