### PR TITLE
Extend allowed memory for GCP functions

### DIFF
--- a/packages/gcp-functions/src/executors/deploy/deploy.impl.ts
+++ b/packages/gcp-functions/src/executors/deploy/deploy.impl.ts
@@ -3,13 +3,15 @@ import { buildCommand, execCommand } from '@nx-extend/core'
 import { join } from 'path'
 
 import { getValidSecrets } from '../../utils/get-valid-secrets'
+import { Gen, ValidMemory } from '../../types'
+import { validateResources } from '../../utils/validate-resources'
 
 export interface DeployExecutorSchema {
   functionName: string
   runtime?: 'nodejs16' | 'nodejs18' | 'nodejs20' | 'recommended'
   entryPoint?: string
   serviceAccount?: string
-  memory?: '128MB' | '256MB' | '512MB' | '1024MB' | '2048MB' | '4096MB'
+  memory?: ValidMemory
   region: string
   envVarsFile?: string
   envVars?: Record<string, string>
@@ -28,7 +30,7 @@ export interface DeployExecutorSchema {
   secrets?: string[] | Record<string, string>
 
   // Gen 2 options
-  gen?: 1 | 2
+  gen?: Gen
   concurrency?: number
   timeout?: number
   cloudSqlInstance?: string
@@ -80,6 +82,8 @@ export async function deployExecutor(
 
     allowUnauthenticated = trigger === 'http'
   } = options
+
+  validateResources({ cpu, memory, gen })
 
   let correctMemory = memory as string
   let correctCPU = cpu as number

--- a/packages/gcp-functions/src/executors/deploy/schema.json
+++ b/packages/gcp-functions/src/executors/deploy/schema.json
@@ -17,7 +17,13 @@
     "trigger": {
       "type": "string",
       "description": "Trigger type",
-      "enum": ["http", "bucket", "topic", "resource", "event"]
+      "enum": [
+        "http",
+        "bucket",
+        "topic",
+        "resource",
+        "event"
+      ]
     },
     "triggerValue": {
       "type": "string",
@@ -25,7 +31,12 @@
     },
     "runtime": {
       "type": "string",
-      "enum": ["nodejs16", "nodejs18", "nodejs20", "recommended"]
+      "enum": [
+        "nodejs16",
+        "nodejs18",
+        "nodejs20",
+        "recommended"
+      ]
     },
     "memory": {
       "type": "string",
@@ -59,18 +70,28 @@
     },
     "ingressSettings": {
       "type": "string",
-      "enum": ["all", "internal-only", "internal-and-gclb"]
+      "enum": [
+        "all",
+        "internal-only",
+        "internal-and-gclb"
+      ]
     },
     "egressSettings": {
       "type": "string",
-      "enum": ["all", "private-ranges-only"]
+      "enum": [
+        "all",
+        "private-ranges-only"
+      ]
     },
     "vpcConnector": {
       "type": "string"
     },
     "securityLevel": {
       "type": "string",
-      "enum": ["secure-optional", "secure-always"]
+      "enum": [
+        "secure-optional",
+        "secure-always"
+      ]
     },
     "gen": {
       "type": "number",

--- a/packages/gcp-functions/src/executors/deploy/schema.json
+++ b/packages/gcp-functions/src/executors/deploy/schema.json
@@ -17,13 +17,7 @@
     "trigger": {
       "type": "string",
       "description": "Trigger type",
-      "enum": [
-        "http",
-        "bucket",
-        "topic",
-        "resource",
-        "event"
-      ]
+      "enum": ["http", "bucket", "topic", "resource", "event"]
     },
     "triggerValue": {
       "type": "string",
@@ -31,12 +25,7 @@
     },
     "runtime": {
       "type": "string",
-      "enum": [
-        "nodejs16",
-        "nodejs18",
-        "nodejs20",
-        "recommended"
-      ]
+      "enum": ["nodejs16", "nodejs18", "nodejs20", "recommended"]
     },
     "memory": {
       "type": "string",
@@ -46,7 +35,10 @@
         "512MB",
         "1024MB",
         "2048MB",
-        "4096MB"
+        "4096MB",
+        "8192MB",
+        "16384MB",
+        "32768MB"
       ]
     },
     "allowUnauthenticated": {
@@ -67,28 +59,18 @@
     },
     "ingressSettings": {
       "type": "string",
-      "enum": [
-        "all",
-        "internal-only",
-        "internal-and-gclb"
-      ]
+      "enum": ["all", "internal-only", "internal-and-gclb"]
     },
     "egressSettings": {
       "type": "string",
-      "enum": [
-        "all",
-        "private-ranges-only"
-      ]
+      "enum": ["all", "private-ranges-only"]
     },
     "vpcConnector": {
       "type": "string"
     },
     "securityLevel": {
       "type": "string",
-      "enum": [
-        "secure-optional",
-        "secure-always"
-      ]
+      "enum": ["secure-optional", "secure-always"]
     },
     "gen": {
       "type": "number",

--- a/packages/gcp-functions/src/index.ts
+++ b/packages/gcp-functions/src/index.ts
@@ -1,1 +1,0 @@
-export * from './utils/validate-cpu-memory';

--- a/packages/gcp-functions/src/index.ts
+++ b/packages/gcp-functions/src/index.ts
@@ -1,0 +1,1 @@
+export * from './utils/validate-cpu-memory';

--- a/packages/gcp-functions/src/types/index.ts
+++ b/packages/gcp-functions/src/types/index.ts
@@ -1,0 +1,12 @@
+export type ValidMemory =
+  | '128MB'
+  | '256MB'
+  | '512MB'
+  | '1024MB'
+  | '2048MB'
+  | '4096MB'
+  | '8192MB'
+  | '16384MB'
+  | '32768MB'
+
+export type Gen = 1 | 2

--- a/packages/gcp-functions/src/utils/validate-resources.spec.ts
+++ b/packages/gcp-functions/src/utils/validate-resources.spec.ts
@@ -1,0 +1,64 @@
+import { validateResources } from './validate-resources'
+import { Gen, ValidMemory } from '../types'
+
+describe('validateResources', () => {
+  it('should throw an error if memory is gen2 and gen is 1', () => {
+    const resources = {
+      cpu: 4,
+      memory: '16384MB' as const,
+      gen: 1 as const
+    }
+
+    expect(() => validateResources(resources)).toThrow()
+  })
+
+  it('should throw an error if CPU is less than minimum required for memory', () => {
+    const resources = {
+      cpu: 0.5,
+      memory: '1024MB' as const,
+      gen: 2 as const
+    }
+
+    expect(() => validateResources(resources)).toThrow()
+  })
+
+  it('should not throw an error for valid resources', () => {
+    const resources = {
+      cpu: 1,
+      memory: '1024MB' as ValidMemory,
+      gen: 2 as Gen
+    }
+
+    expect(() => validateResources(resources)).not.toThrow()
+  })
+
+  it('should not throw an error for gen2 memory and gen 2', () => {
+    const resources = {
+      cpu: 4,
+      memory: '16384MB' as const,
+      gen: 2 as Gen
+    }
+
+    expect(() => validateResources(resources)).not.toThrow()
+  })
+
+  it('should not throw an error for minimum CPU and memory', () => {
+    const resources = {
+      cpu: 0.083,
+      memory: '128MB' as const,
+      gen: 2 as const
+    }
+
+    expect(() => validateResources(resources)).not.toThrow()
+  })
+
+  it('should not throw an error if CPU is higher than minimum required for memory', () => {
+    const resources = {
+      cpu: 1,
+      memory: '256MB' as const,
+      gen: 1 as const
+    }
+
+    expect(() => validateResources(resources)).not.toThrow()
+  })
+})

--- a/packages/gcp-functions/src/utils/validate-resources.ts
+++ b/packages/gcp-functions/src/utils/validate-resources.ts
@@ -1,0 +1,43 @@
+import { Gen, ValidMemory } from '../types'
+
+const gen2Memory: ValidMemory[] = ['16384MB', '32768MB']
+const minimumCPU: Record<ValidMemory, number> = {
+  '128MB': 0.083,
+  '256MB': 0.167,
+  '512MB': 0.333,
+  '1024MB': 0.583,
+  '2048MB': 1,
+  '4096MB': 2,
+  '8192MB': 2,
+  '16384MB': 4,
+  '32768MB': 8
+}
+const docsLink = 'https://cloud.google.com/functions/docs/configuring/memory'
+
+export const validateResources = ({
+  cpu,
+  memory,
+  gen
+}: {
+  cpu: number
+  memory: ValidMemory
+  gen: Gen
+}) => {
+  if (gen2Memory.includes(memory) && gen === 1) {
+    throw new Error(
+      `Setting memory to "${memory}" is not supported when gen is 2.
+
+       See ${docsLink} for more information.
+      `
+    )
+  }
+
+  if (cpu < minimumCPU[memory]) {
+    throw new Error(
+      `CPU value of ${cpu} is not enough for memory of ${memory}.
+      
+       See ${docsLink} for more information
+      `
+    )
+  }
+}


### PR DESCRIPTION
- Allows 8 GB memory for Gen 1 functions
- Allows 16 GB and 32GB for Gen 2 functions
- Adds validation logic to ensure that CPU allocations are consistent with memory limits