### PR TITLE
Update peerDeps to allow react 19

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -30,8 +30,8 @@
     "@nx/devkit": "^20.0.0",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.1",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "builders": "./executors.json",
   "generators": "./generators.json"


### PR DESCRIPTION
As per [@docusaurus/core package.json](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus/package.json) and the [release notes](https://github.com/facebook/docusaurus/releases/tag/v3.7.0) docusaurus supports react 19 since 3.7.0. This would enable nx-extend/docusaurus to be installed in codebases that use React-router 7, and other codebases that use react 19.