### PR TITLE
chore(docusaurus): bump @nx/devkit to ^21.0.0

### DIFF
--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -27,7 +27,7 @@
     "@docusaurus/core": "^3.4.0",
     "@docusaurus/preset-classic": "^3.4.0",
     "@mdx-js/react": "^3.0.1",
-    "@nx/devkit": "^20.0.0",
+    "@nx/devkit": "^21.0.0",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6213,7 +6213,7 @@ __metadata:
     "@docusaurus/core": ^3.4.0
     "@docusaurus/preset-classic": ^3.4.0
     "@mdx-js/react": ^3.0.1
-    "@nx/devkit": ^20.0.0
+    "@nx/devkit": ^21.0.0
     clsx: ^2.1.1
     prism-react-renderer: ^2.3.1
     react: ^18.3.1


### PR DESCRIPTION
In 4.0.0 Nx was upgraded to 21 but the peer dependency for @nx/devkit was still set to 20. This updates the peer dependency ^21.0.0.