### PR TITLE
fix(react-email): Dynamically append `react-email` version in serve e…

### DIFF
--- a/packages/react-email/src/executors/serve/serve.impl.ts
+++ b/packages/react-email/src/executors/serve/serve.impl.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext } from '@nx/devkit'
+import { ExecutorContext, getDependencyVersionFromPackageJson } from '@nx/devkit'
 import { buildCommand, execPackageManagerCommand } from '@nx-extend/core'
 
 import 'dotenv/config'
@@ -13,8 +13,10 @@ export async function serveExecutor(
 ): Promise<{ success: boolean }> {
   const { sourceRoot, root } = context.projectsConfigurations.projects[context.projectName]
 
+  const reactEmailVersion = getDependencyVersionFromPackageJson('react-email')
+
   return execPackageManagerCommand(buildCommand([
-    'react-email dev',
+    `react-email${reactEmailVersion ? `@${reactEmailVersion}` : ''} dev`,
     `--dir=${sourceRoot || root}`,
     options.port && `--port=${options.port}`
   ]), {


### PR DESCRIPTION
…xecutor

- Utilized `getDependencyVersionFromPackageJson` to fetch `react-email` version.
- Updated the serve command to include version-specific `react-email` invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Development server now automatically uses the installed react-email version when running the CLI, ensuring consistent behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->