### PR TITLE
add option to specify Terraform working directory

### DIFF
--- a/packages/terraform/README.md
+++ b/packages/terraform/README.md
@@ -117,19 +117,20 @@ nx run <terraform-project-name>:fmt
 
 | Name                  | Type      | Default  | Description                                                                                    | Supported Commands                 |
 |:----------------------|:----------|:---------|:-----------------------------------------------------------------------------------------------|:-----------------------------------|
-| **`ciMode`**          | `boolean` | `false`  | Enables CI mode (sets `TF_IN_AUTOMATION=true` and `TF_INPUT=0`)                               | All                                |
+| **`ciMode`**          | `boolean` | `false`  | Enables CI mode (sets `TF_IN_AUTOMATION=true` and `TF_INPUT=0`)                                | All                                |
 | **`varFile`**         | `string`  | -        | Path to a variable file (passed as `--var-file`)                                               | `plan`, `apply`, `test`            |
 | **`varString`**       | `string`  | -        | Inline variables (passed as `--var`)                                                           | `plan`, `apply`, `test`            |
 | **`planFile`**        | `string`  | -        | Path to output the plan file (e.g., `tfplan`)                                                  | `plan`, `apply`                    |
 | **`autoApproval`**    | `boolean` | `false`  | Skips interactive approval (passed as `-auto-approve`)                                         | `apply`, `destroy`                 |
-| **`workspace`**       | `string`  | -        | Name of the workspace. **Required** for `new`, `select`, and `delete` actions                 | `workspace`                        |
-| **`workspaceAction`** | `string`  | `select` | Action to perform on the workspace. Accepted values: `select`, `new`, `delete`, `list`        | `workspace`                        |
-| **`backendConfig`**   | `array`   | `[]`     | Backend configuration (e.g., `[{ "key": "bucket", "name": "my-bucket" }]`)                    | `init`                             |
+| **`workspace`**       | `string`  | -        | Name of the workspace. **Required** for `new`, `select`, and `delete` actions                  | `workspace`                        |
+| **`workspaceAction`** | `string`  | `select` | Action to perform on the workspace. Accepted values: `select`, `new`, `delete`, `list`         | `workspace`                        |
+| **`backendConfig`**   | `array`   | `[]`     | Backend configuration (e.g., `[{ "key": "bucket", "name": "my-bucket" }]`)                     | `init`                             |
 | **`reconfigure`**     | `boolean` | `false`  | Reconfigure the backend (passed as `-reconfigure`)                                             | `init`                             |
 | **`migrateState`**    | `boolean` | `false`  | Migrate state during init (passed as `-migrate-state`)                                         | `init`                             |
 | **`upgrade`**         | `boolean` | `false`  | Install the latest module and provider versions (passed as `-upgrade`)                         | `init`                             |
 | **`formatWrite`**     | `boolean` | `false`  | If `true`, updates files in place. If `false`, only checks formatting                          | `fmt`                              |
 | **`lock`**            | `boolean` | `false`  | Update the lock file (passed as `lock`)                                                        | `providers`                        |
+| **`root`**            | `string`  | -        | Path to the Terraform working directory                                                        | `all`                              |
 
 ## Usage Examples
 

--- a/packages/terraform/README.md
+++ b/packages/terraform/README.md
@@ -130,7 +130,7 @@ nx run <terraform-project-name>:fmt
 | **`upgrade`**         | `boolean` | `false`  | Install the latest module and provider versions (passed as `-upgrade`)                         | `init`                             |
 | **`formatWrite`**     | `boolean` | `false`  | If `true`, updates files in place. If `false`, only checks formatting                          | `fmt`                              |
 | **`lock`**            | `boolean` | `false`  | Update the lock file (passed as `lock`)                                                        | `providers`                        |
-| **`root`**            | `string`  | -        | Path to the Terraform working directory                                                        | `all`                              |
+| **`root`**            | `string`  | -        | Working dir: executor `root`, then project.json `terraformRoot`, then `sourceRoot`             | `all`                              |
 
 ## Usage Examples
 

--- a/packages/terraform/src/executors/apply/schema.json
+++ b/packages/terraform/src/executors/apply/schema.json
@@ -5,5 +5,10 @@
   "type": "object",
   "title": "Apply executor",
   "description": "Apply",
-  "properties": {}
+  "properties": {
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
+    }
+  }
 }

--- a/packages/terraform/src/executors/destroy/schema.json
+++ b/packages/terraform/src/executors/destroy/schema.json
@@ -5,5 +5,10 @@
   "type": "object",
   "title": "Destroy executor",
   "description": "Destroy",
-  "properties": {}
+  "properties": {
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
+    }
+  }
 }

--- a/packages/terraform/src/executors/fmt/schema.json
+++ b/packages/terraform/src/executors/fmt/schema.json
@@ -11,6 +11,10 @@
       "title": "Write to file",
       "description": "Write to file",
       "default": false
+    },
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
     }
   }
 }

--- a/packages/terraform/src/executors/init/schema.json
+++ b/packages/terraform/src/executors/init/schema.json
@@ -17,6 +17,10 @@
       "title": "Reconfigure a backend, and attempt to migrate any existing state.",
       "description": "Reconfigure a backend, and attempt to migrate any existing state.",
       "default": false
+    },
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
     }
   }
 }

--- a/packages/terraform/src/executors/plan/schema.json
+++ b/packages/terraform/src/executors/plan/schema.json
@@ -5,5 +5,10 @@
   "type": "object",
   "title": "Plan executor",
   "description": "Plan",
-  "properties": {}
+  "properties": {
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
+    }
+  }
 }

--- a/packages/terraform/src/executors/providers/schema.json
+++ b/packages/terraform/src/executors/providers/schema.json
@@ -11,6 +11,10 @@
       "title": "Write out dependency locks for the configured providers.",
       "description": "Write out dependency locks for the configured providers.",
       "default": false
+    },
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
     }
   }
 }

--- a/packages/terraform/src/executors/test/schema.json
+++ b/packages/terraform/src/executors/test/schema.json
@@ -5,5 +5,10 @@
   "type": "object",
   "title": "Test executor",
   "description": "Test",
-  "properties": {}
+  "properties": {
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
+    }
+  }
 }

--- a/packages/terraform/src/executors/validate/schema.json
+++ b/packages/terraform/src/executors/validate/schema.json
@@ -5,5 +5,10 @@
   "type": "object",
   "title": "Validate executor",
   "description": "Validate",
-  "properties": {}
+  "properties": {
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
+    }
+  }
 }

--- a/packages/terraform/src/executors/workspace/schema.json
+++ b/packages/terraform/src/executors/workspace/schema.json
@@ -17,6 +17,10 @@
     "ciMode": {
       "type": "boolean",
       "default": true
+    },
+    "root": {
+      "type": "string",
+      "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."
     }
   }
 }

--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -37,8 +37,11 @@ export function createExecutor(command: string) {
     }
 
     const projectConfig = context.projectsConfigurations?.projects?.[projectName]
-    const projectTerraformRoot = projectConfig && 'terraformRoot' in projectConfig 
-      ? (projectConfig as Record<string, any>).terraformRoot 
+    const terraformRootValue = projectConfig && 'terraformRoot' in projectConfig
+      ? (projectConfig as Record<string, unknown>).terraformRoot
+      : undefined
+    const projectTerraformRoot = typeof terraformRootValue === 'string'
+      ? terraformRootValue
       : undefined
     const defaultSourceRoot = projectConfig?.sourceRoot
 

--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -4,6 +4,7 @@ import { execSync } from 'child_process'
 import { which } from 'shelljs'
 
 export interface ExecutorOptions {
+  root?: string // Local target options override
   backendConfig: { key: string; name: string }[]
   autoApproval: boolean
   planFile: string
@@ -30,7 +31,21 @@ export function createExecutor(command: string) {
       throw new Error('Terraform is not installed!')
     }
 
-    const { sourceRoot } = context.projectsConfigurations.projects[context.projectName]
+    const projectName = context.projectName
+    if (!projectName) {
+      throw new Error('Project name is required in executor context')
+    }
+
+    const projectConfig = context.projectsConfigurations?.projects?.[projectName]
+    const projectTerraformRoot = projectConfig && 'terraformRoot' in projectConfig 
+      ? (projectConfig as Record<string, any>).terraformRoot 
+      : undefined
+    const defaultSourceRoot = projectConfig?.sourceRoot
+
+    const targetDirectory = options.root ??
+                projectTerraformRoot ??
+                defaultSourceRoot
+
     const {
       backendConfig = [],
       planFile,
@@ -98,7 +113,7 @@ export function createExecutor(command: string) {
         command === 'test' && varString && `--var ${varString}`
       ]),
       {
-        cwd: sourceRoot,
+        cwd: targetDirectory,
         stdio: 'inherit',
         env: {
           ...process.env,


### PR DESCRIPTION
fixes #482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `root` setting to run Terraform tasks from a custom working directory.
  * Supported this `root` override consistently across plan, apply, destroy, init, validate, test, fmt, workspace, and providers tasks.

* **Documentation**
  * Updated the Terraform “Available Options” documentation to include `root`, including its intended behavior and supported command coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->