### PR TITLE
feat(terraform,core): support nx 23

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "peerDependencies": {
-    "@nx/devkit": "^22.0.0"
+    "@nx/devkit": "^22.0.0 || ^23.0.0"
   },
   "nx-migrations": {
     "migrations": "./migrations.json"

--- a/packages/core/src/utils/exec-package-manager-command.ts
+++ b/packages/core/src/utils/exec-package-manager-command.ts
@@ -1,7 +1,7 @@
 import {
   detectPackageManager,
   getPackageManagerCommand as nxGetPackageManagerCommand
-} from 'nx/src/utils/package-manager'
+} from '@nx/devkit'
 
 import { buildCommand } from './build-command'
 import { execCommand, Options } from './exec'

--- a/packages/terraform/package.json
+++ b/packages/terraform/package.json
@@ -19,7 +19,7 @@
     "hcl2-json-parser": "^1.0.1"
   },
   "peerDependencies": {
-    "@nx/devkit": "^22.0.0"
+    "@nx/devkit": "^22.0.0 || ^23.0.0"
   },
   "builders": "./executors.json",
   "generators": "./generators.json"

--- a/packages/terraform/src/graph.ts
+++ b/packages/terraform/src/graph.ts
@@ -1,5 +1,6 @@
 import {
   CreateDependencies,
+  DependencyType,
   logger,
   RawProjectGraphDependency,
   workspaceRoot
@@ -7,7 +8,6 @@ import {
 import * as hcl2JsonParser from 'hcl2-json-parser'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { DependencyType } from 'nx/src/config/project-graph'
 
 const isLocalPath = (path: string) => {
   return path.startsWith('./') || path.startsWith('../')


### PR DESCRIPTION
- widen @nx/devkit peer range to ^22.0.0 || ^23.0.0
- move deprecated deep nx/src imports to @nx/devkit (DependencyType, detectPackageManager, getPackageManagerCommand)

I hope the change is that simple. Please let me know if not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Added support for Nx 23 alongside Nx 22.
  * Improved compatibility with supported Nx package-manager and project-graph APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->