### PR TITLE
feat(terraform): add --lock=false flag for read-only state access

### DIFF
--- a/packages/terraform/README.md
+++ b/packages/terraform/README.md
@@ -129,8 +129,10 @@ nx run <terraform-project-name>:fmt
 | **`migrateState`**    | `boolean` | `false`  | Migrate state during init (passed as `-migrate-state`)                                         | `init`                             |
 | **`upgrade`**         | `boolean` | `false`  | Install the latest module and provider versions (passed as `-upgrade`)                         | `init`                             |
 | **`formatWrite`**     | `boolean` | `false`  | If `true`, updates files in place. If `false`, only checks formatting                          | `fmt`                              |
-| **`lock`**            | `boolean` | `false`  | Update the lock file (passed as `lock`)                                                        | `providers`                        |
+| **`lock`**            | `boolean` | `true`   | `init`/`plan`: skip state file locking. Warning: dangerous `providers`: Update the lock file   | `init`, `plan`, `providers`        |
 | **`root`**            | `string`  | -        | Working dir: executor `root`, then project.json `terraformRoot`, then `sourceRoot`             | `all`                              |
+
+> **Note on `lock` option:** For `init` and `plan` commands, setting `lock=false` skips acquiring a lock on the state file, allowing operations on read-only state storage. However, disabling locks can lead to state corruption if concurrent state-changing operations are performed on the same state. Only disable locking when you have read-only access and are certain no other processes are modifying the state.
 
 ## Usage Examples
 

--- a/packages/terraform/src/executors/init/schema.json
+++ b/packages/terraform/src/executors/init/schema.json
@@ -18,6 +18,12 @@
       "description": "Reconfigure a backend, and attempt to migrate any existing state.",
       "default": false
     },
+    "lock": {
+      "type": "boolean",
+      "title": "Lock state during init",
+      "description": "Don't hold a state lock during backend migration. This is dangerous if others might concurrently run commands against the same workspace.",
+      "default": true
+    },
     "root": {
       "type": "string",
       "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."

--- a/packages/terraform/src/executors/plan/schema.json
+++ b/packages/terraform/src/executors/plan/schema.json
@@ -6,6 +6,12 @@
   "title": "Plan executor",
   "description": "Plan",
   "properties": {
+    "lock": {
+      "type": "boolean",
+      "title": "Lock state during plan",
+      "description": "Don't hold a state lock during the operation. This is dangerous if others might concurrently run commands against the same workspace.",
+      "default": true
+    },
     "root": {
       "type": "string",
       "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."

--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -102,6 +102,7 @@ export function createExecutor(command: string) {
         command === 'plan' && planFile && `-out ${planFile}`,
         command === 'plan' && varFile && `--var-file ${varFile}`,
         command === 'plan' && varString && `--var ${varString}`,
+        command === 'plan' && lock === false && '-lock=false',
         command === 'destroy' && autoApproval && '-auto-approve',
         command === 'apply' && autoApproval && '-auto-approve',
         command === 'apply' && planFile,
@@ -111,6 +112,7 @@ export function createExecutor(command: string) {
         command === 'init' && upgrade && '-upgrade',
         command === 'init' && migrateState && '-migrate-state',
         command === 'init' && reconfigure && '-reconfigure',
+        command === 'init' && lock === false && '-lock=false',
         command === 'providers' && lock && 'lock',
         command === 'test' && varFile && `--var-file ${varFile}`,
         command === 'test' && varString && `--var ${varString}`


### PR DESCRIPTION
## Summary

Add support for read-only state access by introducing a `--lock` flag to init and plan executors. When set to false, passes `-lock=false` to Terraform commands, allowing teams with read-only permissions to run plan and init operations without requiring write access to state files.

Closes #495

## Use Cases

- CI/CD pipelines with read-only state access (e.g., plan-only runs)
- Developers auditing infrastructure without write permissions
- Organizations implementing least-privilege access controls
- Seamless switching between environments with different permission levels

## Example Usage

```bash
# Single environment (state file exists)
nx run service:plan --lock=false

# Switching environments (with backend reconfiguration)
nx run service:initialize --reconfigure --lock=false
nx run service:plan -c uat --lock=false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `lock` option to Terraform `init` and `plan` commands (default: `true`).
  - When `lock` is explicitly `false`, `init`/`plan` run with state locking disabled.

- **Documentation**
  - Updated the Terraform `lock` option documentation, expanding behavior from `providers`-only to `init`, `plan`, and `providers`.
  - Added guidance warning that disabling locks on `init`/`plan` can cause state corruption if concurrent state-changing operations occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->