### PR TITLE
feat(terraform): add provider management support with caching and mirroring

### DIFF
--- a/packages/terraform/README.md
+++ b/packages/terraform/README.md
@@ -130,6 +130,11 @@ nx run <terraform-project-name>:fmt
 | **`upgrade`**         | `boolean` | `false`  | Install the latest module and provider versions (passed as `-upgrade`)                         | `init`                             |
 | **`formatWrite`**     | `boolean` | `false`  | If `true`, updates files in place. If `false`, only checks formatting                          | `fmt`                              |
 | **`lock`**            | `boolean` | `true`   | `init`/`plan`: skip state file locking. Warning: dangerous `providers`: Update the lock file   | `init`, `plan`, `providers`        |
+| **`cacheEnabled`**    | `boolean` | `false`  | Enable plugin cache for lock operations. Speeds up locking but providers aren't authoritative. | `providers`                        |
+| **`cacheDir`**        | `string`  | -        | Directory for caching downloaded providers (sets `TF_PLUGIN_CACHE_DIR`)                        | `init`, `providers`                |
+| **`mirror`**          | `boolean` | `false`  | Mirror providers to a local directory for offline installation                                 | `providers`                        |
+| **`mirrorDir`**       | `string`  | -        | Directory where mirrored providers will be written (used with `mirror: true`)                  | `providers`                        |
+| **`platforms`**       | `array`   | -        | Target platforms for lock and mirror operations (e.g., `["linux_amd64", "darwin_arm64"]`)      | `providers`                        |
 | **`root`**            | `string`  | -        | Working dir: executor `root`, then project.json `terraformRoot`, then `sourceRoot`             | `all`                              |
 
 > **Note on `lock` option:** For `init` and `plan` commands, setting `lock=false` skips acquiring a lock on the state file, allowing operations on read-only state storage. However, disabling locks can lead to state corruption if concurrent state-changing operations are performed on the same state. Only disable locking when you have read-only access and are certain no other processes are modifying the state.

--- a/packages/terraform/src/executors/init/schema.json
+++ b/packages/terraform/src/executors/init/schema.json
@@ -24,6 +24,12 @@
       "description": "Don't hold a state lock during backend migration. This is dangerous if others might concurrently run commands against the same workspace.",
       "default": true
     },
+    "cacheDir": {
+      "type": "string",
+      "title": "Terraform plugin cache directory",
+      "description": "Optional: Directory where terraform will cache downloaded providers. If not specified, terraform uses default behavior (no shared cache).",
+      "examples": [".terraform-plugin-cache", "/tmp/terraform-cache"]
+    },
     "root": {
       "type": "string",
       "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."

--- a/packages/terraform/src/executors/providers/schema.json
+++ b/packages/terraform/src/executors/providers/schema.json
@@ -12,6 +12,37 @@
       "description": "Write out dependency locks for the configured providers.",
       "default": false
     },
+    "cacheEnabled": {
+      "type": "boolean",
+      "title": "Enable plugin cache for lock operations.",
+      "description": "Enable the plugin cache when locking providers. This speeds up the locking process but providers won't be loaded from an authoritative source. Requires cacheDir to be configured.",
+      "default": false
+    },
+    "cacheDir": {
+      "type": "string",
+      "title": "Terraform plugin cache directory",
+      "description": "Optional: Directory where terraform will cache downloaded providers. If not specified, terraform uses default behavior (no shared cache).",
+      "examples": [".terraform-plugin-cache", "/tmp/terraform-cache"]
+    },
+    "mirror": {
+      "type": "boolean",
+      "title": "Mirror providers to a local directory",
+      "description": "Mirror providers to a local directory for offline installation. Can be combined with lock: true to lock and mirror providers in sequence.",
+      "default": false
+    },
+    "mirrorDir": {
+      "type": "string",
+      "title": "Mirror output directory",
+      "description": "Directory where mirrored providers will be written (used with mirror: true). If not specified, defaults to .terraform/providers.",
+      "examples": [".terraform/providers", "terraform-mirror"]
+    },
+    "platforms": {
+      "type": "array",
+      "items": { "type": "string" },
+      "title": "Target platforms for provider operations",
+      "description": "Target specific platforms for provider lock and mirror operations (e.g., linux_amd64, darwin_amd64). Used with lock and/or mirror flags.",
+      "examples": [["linux_amd64", "darwin_amd64"]]
+    },
     "root": {
       "type": "string",
       "description": "Ad-hoc task override path to the Terraform working directory. Overrides project-level terraformRoot."

--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -1,7 +1,8 @@
 import { ExecutorContext } from '@nx/devkit'
-import { buildCommand } from '@nx-extend/core'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import { which } from 'shelljs'
+import * as path from 'path'
+import { mkdirSync } from 'fs'
 
 export interface ExecutorOptions {
   root?: string // Local target options override
@@ -18,6 +19,11 @@ export interface ExecutorOptions {
   reconfigure: boolean
   workspace: string
   workspaceAction: 'select' | 'new' | 'delete' | 'list'
+  cacheDir?: string
+  cacheEnabled?: boolean
+  mirror?: boolean
+  mirrorDir?: string
+  platforms?: string[]
 
   [key: string]: string | unknown
 }
@@ -60,17 +66,32 @@ export function createExecutor(command: string) {
       lock,
       varFile,
       varString,
-      reconfigure,  
-      workspace,  
-      workspaceAction = 'select'
+      reconfigure,
+      workspace,
+      workspaceAction = 'select',
+      cacheDir,
+      cacheEnabled,
+      mirror,
+      mirrorDir,
+      platforms = []
     } = options
 
-    let env = {}
+    const env: Record<string, string | number | boolean> = {}
     if (ciMode) {
-      env = {
-        TF_IN_AUTOMATION: true,
-        TF_INPUT: 0
-      }
+      env.TF_IN_AUTOMATION = true
+      env.TF_INPUT = 0
+    }
+
+    let resolvedCacheDir = ''
+    if (cacheDir) {
+      resolvedCacheDir = path.isAbsolute(cacheDir) ? cacheDir : path.resolve(targetDirectory || '.', cacheDir)
+      mkdirSync(resolvedCacheDir, { recursive: true })
+      env.TF_PLUGIN_CACHE_DIR = resolvedCacheDir
+    }
+
+    let resolvedMirrorDir = mirrorDir
+    if (mirror && !resolvedMirrorDir) {
+      resolvedMirrorDir = path.resolve(targetDirectory || '.', '.terraform', 'providers')
     }
 
     let workspaceArgs: string[] = [];
@@ -91,9 +112,46 @@ export function createExecutor(command: string) {
       jsonBackendConfig = JSON.parse(jsonBackendConfig)
     }
 
-    execSync(
-      buildCommand([
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const processEnv = (globalThis as any).process?.env || {}
+    const execEnv = {
+      ...processEnv,
+      ...env
+    }
+
+    // Handle provider lock and mirror commands
+    if (command === 'providers' && lock && mirror) {
+      execFileSync(
         'terraform',
+        [
+          'providers',
+          'lock',
+          ...(cacheEnabled ? ['-enable-plugin-cache'] : []),
+          ...(platforms.length > 0 ? platforms.map(p => `-platform=${p}`) : [])
+        ],
+        {
+          cwd: targetDirectory,
+          stdio: 'inherit',
+          env: execEnv
+        }
+      )
+
+      execFileSync(
+        'terraform',
+        [
+          'providers',
+          'mirror',
+          ...(platforms.length > 0 ? platforms.map(p => `-platform=${p}`) : []),
+          resolvedMirrorDir!
+        ],
+        {
+          cwd: targetDirectory,
+          stdio: 'inherit',
+          env: execEnv
+        }
+      )
+    } else {
+      const args = [
         command,
         ...workspaceArgs,
         ...(command === 'init' ? jsonBackendConfig.map(
@@ -114,18 +172,25 @@ export function createExecutor(command: string) {
         command === 'init' && reconfigure && '-reconfigure',
         command === 'init' && lock === false && '-lock=false',
         command === 'providers' && lock && 'lock',
+        ...(command === 'providers' && lock && cacheEnabled ? ['-enable-plugin-cache'] : []),
+        ...(command === 'providers' && lock && platforms.length > 0 ? platforms.map(p => `-platform=${p}`) : []),
+        command === 'providers' && mirror && 'mirror',
+        ...(command === 'providers' && mirror && platforms.length > 0 ? platforms.map(p => `-platform=${p}`) : []),
+        command === 'providers' && mirror && resolvedMirrorDir,
         command === 'test' && varFile && `--var-file ${varFile}`,
         command === 'test' && varString && `--var ${varString}`
-      ]),
-      {
-        cwd: targetDirectory,
-        stdio: 'inherit',
-        env: {
-          ...process.env,
-          ...env
+      ].filter((arg): arg is string => typeof arg === 'string' && arg !== '')
+
+      execFileSync(
+        'terraform',
+        args,
+        {
+          cwd: targetDirectory,
+          stdio: 'inherit',
+          env: execEnv
         }
-      }
-    )
+      )
+    }
 
     return Promise.resolve({ success: true })
   }


### PR DESCRIPTION
Add support for provider caching and mirroring to enable offline deployments and reduce bandwidth usage. New flags allow teams to:

- Cache providers locally with --cacheDir (sets TF_PLUGIN_CACHE_DIR)
- Mirror providers for offline use with --mirror and --mirrorDir
- Lock providers for specific platforms with --platforms

Implementation adds:
- cacheDir property to init and providers executors
- mirror, mirrorDir, platforms properties to providers executor
- Environment variable setup for TF_PLUGIN_CACHE_DIR
- Conditional execution of terraform providers lock and mirror commands
- Platform-specific provider targeting
- Updated documentation with new options

All new options are backward compatible with safe defaults.

Closes: #496 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Terraform provider caching and offline local mirroring options: `cacheEnabled`, `cacheDir`, `mirror`, `mirrorDir`, and `platforms`.
  * Supports restricting provider lock and mirror operations to specific target platforms.
  * When locking and mirroring are both enabled, operations run sequentially.
* **Documentation**
  * Updated the Terraform options documentation with defaults, descriptions, and supported commands.
* **Improvements**
  * Terraform commands now honor configured cache and mirror settings, including automatic cache directory preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->