### PR TITLE
chore(deps): update yarn.lock for nx 23 support

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5297,7 +5297,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nx-extend/core@workspace:packages/core"
   peerDependencies:
-    "@nx/devkit": ^22.0.0
+    "@nx/devkit": ^22.0.0 || ^23.0.0
   languageName: unknown
   linkType: soft
 
@@ -5464,7 +5464,7 @@ __metadata:
   dependencies:
     hcl2-json-parser: "npm:^1.0.1"
   peerDependencies:
-    "@nx/devkit": ^22.0.0
+    "@nx/devkit": ^22.0.0 || ^23.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Update yarn.lock to reflect dependency changes from #485 (support for Nx 23). This resolves yarn install failures in GitHub Actions CI.

Closes: #499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end build validation to check generated documentation pages and sitemap files in their localized `en/` output directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->