### PR TITLE
fix(terraform): remove quotes from backend-config arguments in init

### DIFF
--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -155,7 +155,7 @@ export function createExecutor(command: string) {
         command,
         ...workspaceArgs,
         ...(command === 'init' ? jsonBackendConfig.map(
-          (config) => `-backend-config="${config.key}=${config.name}"`
+          (config) => `-backend-config=${config.key}=${config.name}`
         ) : []),
         command === 'plan' && planFile && `-out ${planFile}`,
         command === 'plan' && varFile && `--var-file ${varFile}`,


### PR DESCRIPTION
Closes: #507 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Terraform initialization so backend configuration values are passed without unintended quotation marks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->