### PR TITLE
feat(terraform): add token expansion for path configuration

### DIFF
--- a/packages/terraform/src/utils/create-executor.ts
+++ b/packages/terraform/src/utils/create-executor.ts
@@ -55,6 +55,35 @@ export function createExecutor(command: string) {
                 projectTerraformRoot ??
                 defaultSourceRoot
 
+    // Establish the absolute workspace root reliably
+    const workspaceRoot = context.root
+    // Combine path token expansion and backward-compatible resolution
+    const resolveAndExpandPath = (pathStr: string | undefined): string | undefined => {
+      if (!pathStr) return pathStr
+      // Grab project relative root, default to empty string if missing
+      const projRelativeRoot = projectConfig?.root || ''
+      // Turn it into an absolute project path
+      const absoluteProjectRoot = path.resolve(workspaceRoot, projRelativeRoot)
+      // Global replace using regex to avoid single-instance string.replace bugs
+      const expanded = pathStr
+        .replace(/\{workspaceRoot\}/g, workspaceRoot)
+        .replace(/\{projectRoot\}/g, absoluteProjectRoot)
+      // If workspaceRoot token was used, resolve relative to workspaceRoot
+      if (pathStr.includes('{workspaceRoot}')) {
+        return path.resolve(workspaceRoot, expanded)
+      }
+      // If projectRoot token was used, it's already expanded
+      if (pathStr.includes('{projectRoot}')) {
+        return expanded
+      }
+      // For paths without tokens: return if absolute, otherwise resolve to projectRoot
+      if (path.isAbsolute(expanded)) {
+        return expanded
+      }
+      return path.resolve(absoluteProjectRoot, expanded)
+    }
+
+
     const {
       backendConfig = [],
       planFile,
@@ -82,16 +111,19 @@ export function createExecutor(command: string) {
       env.TF_INPUT = 0
     }
 
-    let resolvedCacheDir = ''
-    if (cacheDir) {
-      resolvedCacheDir = path.isAbsolute(cacheDir) ? cacheDir : path.resolve(targetDirectory || '.', cacheDir)
-      mkdirSync(resolvedCacheDir, { recursive: true })
-      env.TF_PLUGIN_CACHE_DIR = resolvedCacheDir
+    if (cacheEnabled && cacheDir) {
+      const resolvedCacheDir = resolveAndExpandPath(cacheDir)
+      if (resolvedCacheDir) {
+        mkdirSync(resolvedCacheDir, { recursive: true })
+        env.TF_PLUGIN_CACHE_DIR = resolvedCacheDir
+      }
     }
 
-    let resolvedMirrorDir = mirrorDir
+    let resolvedMirrorDir = mirrorDir ? resolveAndExpandPath(mirrorDir) : undefined
     if (mirror && !resolvedMirrorDir) {
-      resolvedMirrorDir = path.resolve(targetDirectory || '.', '.terraform', 'providers')
+      const projRelativeRoot = projectConfig?.root || ''
+      const absoluteProjectRoot = path.resolve(workspaceRoot, projRelativeRoot)
+      resolvedMirrorDir = path.resolve(absoluteProjectRoot, '.terraform', 'providers')
     }
 
     let workspaceArgs: string[] = [];


### PR DESCRIPTION
Add support for {workspaceRoot} and {projectRoot} token expansion in cacheDir and mirrorDir options, allowing more flexible path configuration. Improves path resolution to use workspace root and project root consistently.

Closes: #509 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local path resolution for workspace and project settings, making path-based configuration more reliable.
  * Fixed plugin cache and provider mirror directory handling so nested directories are created automatically when needed.
  * Ensured the plugin cache location is correctly exposed through `TF_PLUGIN_CACHE_DIR`.
  * Updated fallback behavior to resolve paths from the workspace or project root, reducing unexpected configuration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->