### PR TITLE
fix(strapi): resolve @strapi/admin from the strapi project

### DIFF
--- a/packages/strapi/src/executors/build/build.impl.ts
+++ b/packages/strapi/src/executors/build/build.impl.ts
@@ -1,7 +1,5 @@
 import { ExecutorContext, workspaceRoot } from '@nx/devkit'
 // @ts-expect-error it is there but there are no interfaces
-import { build as nodeBuild } from '@strapi/admin/cli'
-// @ts-expect-error it is there but there are no interfaces
 import tsUtils from '@strapi/typescript-utils'
 import { join } from 'path'
 
@@ -47,6 +45,15 @@ export async function buildExecutor(
 
   const strapiRoot = join(workspaceRoot, options.root || root)
   const tsConfig = loadTsConfig(workspaceRoot, options.tsConfig)
+
+  // Resolved from the Strapi project rather than from this plugin. In an npm
+  // workspace `@strapi/admin` is a dependency of the project's `@strapi/strapi`
+  // and npm may leave it nested there, in which case a plain top-level import
+  // of `@strapi/admin/cli` cannot see it and the executor dies before it runs.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { build: nodeBuild } = require(
+    require.resolve('@strapi/admin/cli', { paths: [strapiRoot, workspaceRoot] })
+  )
 
   // nodeBuild somehow only compiles the admin panel
   await tsUtils.compile(strapiRoot, {


### PR DESCRIPTION
The build executor imports `@strapi/admin/cli` at module scope, so node resolves it from the plugin's own location under node_modules/@nx-extend.

In an npm workspace that fails. `@strapi/admin` is a dependency of the project's `@strapi/strapi`, and npm is free to leave it nested at node_modules/@strapi/strapi/node_modules/@strapi/admin — a path the plugin can never reach. The executor then dies with "Cannot find module '@strapi/admin/cli'" before doing any work, even though the package is installed and exports ./cli correctly.

Resolving from the strapi project root (falling back to the workspace root) finds it wherever npm decided to put it. Hoisted installs are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin build execution in nested npm workspaces.
  * The build process can now locate the required admin tooling from the appropriate project or workspace location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->